### PR TITLE
Add data-testid attributes

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -9,7 +9,7 @@
     "serve": "serve public"
   },
   "dependencies": {
-    "@cloudmosaic/quickstarts": "0.0.20",
+    "@cloudmosaic/quickstarts": "0.0.21",
     "@patternfly/react-core": "^4.101.3",
     "asciidoctor": "^2.2.1",
     "react": "^16.14.0",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudmosaic/quickstarts",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Quickstarts for MAS",
   "files": [
     "dist"

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -16,6 +16,10 @@ import { QuickStart } from "./utils/quick-start-types";
 import "./QuickStartPanelContent.scss";
 // js: Remove AsyncComponent and import QuickStartController directly
 import QuickStartController from "./QuickStartController";
+import {
+  QuickStartContext,
+  QuickStartContextValues,
+} from "./utils/quick-start-context";
 import { camelize } from "./utils/quick-start-utils";
 
 type HandleClose = () => void;
@@ -46,6 +50,10 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   const quickStart = quickStarts.find(
     (qs) => qs.metadata.name === activeQuickStartID
   );
+  const { activeQuickStartState } = React.useContext<QuickStartContextValues>(
+    QuickStartContext
+  );
+  const taskNumber = activeQuickStartState?.taskNumber;
   const nextQuickStarts: QuickStart[] = quickStarts.filter((qs: QuickStart) =>
     quickStart?.spec.nextQuickStart?.includes(qs.metadata.name)
   );
@@ -60,8 +68,23 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
       shadows === Shadows.bottom || shadows === Shadows.both,
   });
 
+  const getStep = () => {
+    const tasks = quickStart.spec.tasks.length;
+    if (Number.parseInt(taskNumber as string) === -1) {
+      return 'intro';
+    } else if (Number.parseInt(taskNumber as string) === tasks) {
+      return 'conclusion'
+    }
+    return Number.parseInt(taskNumber as string) + 1;
+  }
+
   const content = quickStart ? (
-    <DrawerPanelContent isResizable className="co-quick-start-panel-content" data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}>
+    <DrawerPanelContent
+      isResizable
+      className="co-quick-start-panel-content"
+      data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}
+      data-qs={`qs-step-${getStep()}`}
+    >
       <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">
@@ -79,7 +102,10 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
             </Title>
           </div>
           <DrawerActions>
-            <DrawerCloseButton onClick={handleClose} data-testid="qs-drawer-close" />
+            <DrawerCloseButton
+              onClick={handleClose}
+              data-testid="qs-drawer-close"
+            />
           </DrawerActions>
         </DrawerHead>
       </div>

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -16,6 +16,7 @@ import { QuickStart } from "./utils/quick-start-types";
 import "./QuickStartPanelContent.scss";
 // js: Remove AsyncComponent and import QuickStartController directly
 import QuickStartController from "./QuickStartController";
+import { camelize } from "./utils/quick-start-utils";
 
 type HandleClose = () => void;
 
@@ -60,7 +61,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   });
 
   const content = quickStart ? (
-    <DrawerPanelContent isResizable className="co-quick-start-panel-content">
+    <DrawerPanelContent isResizable className="co-quick-start-panel-content" data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}>
       <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">
@@ -78,7 +79,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
             </Title>
           </div>
           <DrawerActions>
-            <DrawerCloseButton onClick={handleClose} />
+            <DrawerCloseButton onClick={handleClose} data-testid="qs-drawer-close" />
           </DrawerActions>
         </DrawerHead>
       </div>

--- a/packages/module/src/catalog/QuickStartTile.tsx
+++ b/packages/module/src/catalog/QuickStartTile.tsx
@@ -11,6 +11,7 @@ import {
   QuickStartContext,
   QuickStartContextValues,
 } from "../utils/quick-start-context";
+import { camelize } from "../utils/quick-start-utils";
 
 import "./QuickStartTile.scss";
 
@@ -60,6 +61,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
       }}
       icon={quickStartIcon}
       className="co-quick-start-tile"
+      data-testid={`qs-card-${camelize(displayName)}`}
       featured={isActive}
       title={
         <QuickStartTileHeader

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -51,6 +51,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
               variant="link"
               isInline
               className="co-quick-start-tile-prerequisites__icon"
+              data-testid="qs-card-prereqs"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/packages/module/src/catalog/QuickStartTileFooter.tsx
+++ b/packages/module/src/catalog/QuickStartTileFooter.tsx
@@ -42,28 +42,28 @@ const QuickStartTileFooter: React.FC<QuickStartTileFooterProps> = ({
     <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
       {status === QuickStartStatus.NOT_STARTED && (
         <FlexItem>
-          <Button onClick={start} variant="link" isInline>
+          <Button onClick={start} variant="link" isInline data-testid="qs-card-notStarted-start">
             {t('quickstart~Start the tour')}
           </Button>
         </FlexItem>
       )}
       {status === QuickStartStatus.IN_PROGRESS && activeQuickStartID !== quickStartId && (
         <FlexItem>
-          <Button variant="link" isInline>
+          <Button variant="link" isInline data-testid="qs-card-inProgress-resume">
             {t('quickstart~Resume the tour')}
           </Button>
         </FlexItem>
       )}
       {status === QuickStartStatus.COMPLETE && (
         <FlexItem>
-          <Button onClick={restart} variant="link" isInline>
+          <Button onClick={restart} variant="link" isInline data-testid="qs-card-complete-restart">
             {t('quickstart~Start the tour')}
           </Button>
         </FlexItem>
       )}
       {status === QuickStartStatus.IN_PROGRESS && (
         <FlexItem>
-          <Button onClick={restart} variant="link" isInline>
+          <Button onClick={restart} variant="link" isInline data-testid="qs-card-inProgress-restart">
             {t('quickstart~Restart the tour')}
           </Button>
         </FlexItem>

--- a/packages/module/src/controller/QuickStartFooter.tsx
+++ b/packages/module/src/controller/QuickStartFooter.tsx
@@ -6,6 +6,7 @@ import {
   QuickStartContext,
   QuickStartContextValues,
 } from "../utils/quick-start-context";
+import { camelize } from "../utils/quick-start-utils";
 
 import "./QuickStartFooter.scss";
 
@@ -65,6 +66,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
         variant="primary"
         onClick={onNext}
         isInline
+        data-testid={`qs-drawer-${camelize(getPrimaryButtonText())}`}
       >
         {getPrimaryButtonText()}
       </Button>
@@ -77,6 +79,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
           variant="secondary"
           onClick={onBack}
           isInline
+          data-testid="qs-drawer-back"
         >
           {t("quickstart~Back")}
         </Button>
@@ -84,7 +87,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
       {status === QuickStartStatus.COMPLETE &&
         showAllLink &&
         onShowAllLinkClick && (
-          <Button variant="link" isInline onClick={onShowAllLinkClick}>
+          <Button variant="link" isInline onClick={onShowAllLinkClick} data-testid="qs-drawer-viewAllTours">
             {t("quickstart~View all tours")}
           </Button>
         )}

--- a/packages/module/src/controller/QuickStartTaskReview.tsx
+++ b/packages/module/src/controller/QuickStartTaskReview.tsx
@@ -46,6 +46,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
         <Radio
           id="review-success"
           name="review-success"
+          data-testid="qs-drawer-check-yes"
           label={t('quickstart~Yes')}
           className="co-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.SUCCESS}
@@ -54,6 +55,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
         <Radio
           id="review-failed"
           name="review-failed"
+          data-testid="qs-drawer-check-no"
           label={t('quickstart~No')}
           className="co-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.FAILED}

--- a/packages/module/src/utils/quick-start-utils.ts
+++ b/packages/module/src/utils/quick-start-utils.ts
@@ -48,3 +48,10 @@ export const filterQuickStarts = (
     },
   );
 };
+
+export const camelize = (str: string) => {
+  return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
+    if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
+    return index === 0 ? match.toLowerCase() : match.toUpperCase();
+  });
+}


### PR DESCRIPTION
Closes https://github.com/cloudmosaic/quickstarts/issues/13

Card:
- Entire card can be identified by `data-testid="qs-card-{camelCasedTitle}`
- Prerequisites info button: `data-testid="qs-card-prereqs"`
- The link button at the bottom can have one of 4 different `data-testid` values:
  - `data-testid="qs-card-notStarted-start"` -> Tour has not been done yet, button text "Start the tour"
  - `data-testid="qs-card-inProgress-resume"` -> Tour is in progress but not currently active, button text "Resume the tour"
  - `data-testid="qs-card-complete-restart"` -> Tour is completed, button text "Start the tour"
  - `data-testid="qs-card-inProgress-restart"` -> Tour is in progress, button text "Restart the tour"
<img width="308" alt="Screen Shot 2021-05-04 at 9 17 13 AM" src="https://user-images.githubusercontent.com/869106/117021086-06f22780-acc5-11eb-9191-a48f8d760242.png">

Drawer:
- Entire card can be identified by `data-testid="qs-drawer-{camelCasedTitle}`
  - Additionally, at the same level there is another attribute `data-qs` with one of these values:
    - `data-qs="qs-step-intro"` if we're at the intro step
    - `data-qs="qs-step-1"` if we're within a task, the last number changes based on the task the user is at
    - `data-qs="qs-step-conclusion"` if we're at the conclusion step
- Close button upper right: `data-testid="qs-drawer-close"`
- Check your work section, `Yes` radio button: `data-testid="qs-drawer-check-yes"`
- Check your work section, `No` radio button: `data-testid="qs-drawer-check-no"`
- Footer buttons
  - Back: `data-testid="qs-drawer-back"`
  - Start tour/Next/Close (Button changes based on context)
    - `data-testid="qs-drawer-startTour"`
    - `data-testid="qs-drawer-next"`
    - `data-testid="qs-drawer-close"`
<img width="471" alt="Screen Shot 2021-05-04 at 9 43 28 AM" src="https://user-images.githubusercontent.com/869106/117021096-09ed1800-acc5-11eb-8315-045f16410a24.png">
